### PR TITLE
Rebase from odo quantile estimator 

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Florian Odronitz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ When inserting the test data (14593 numbers) and compressing every 10 inserts th
 
 # Compression rate
 
-When compressions every 10 inserts, the size of the data structure converges to around 60 elements / bins.
+When compressing every 10 inserts, the size of the data structure converges to around 60 elements / bins.
 
 ![compression rate](https://raw.github.com/odo/quantile_estimator/master/doc/compression.png "compression rate")
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Abstract:
 
 "Skew is prevalent in many data sources such as IP traffic streams. To continually summarize the distribution of such data, a high-biased set of quantiles (e.g., 50th, 90th and 99th percentiles) with finer error guarantees at higher ranks (e.g., errors of 5, 1 and 0.1 percent, respectively) is more useful than uniformly distributed quantiles (e.g., 25th, 50th and 75th percentiles) with uniform error guarantees. In this paper, we address the following two problems. First, can we compute quantiles with finer error guarantees for the higher ranks of the data distribution effectively, using less space and computation time than computing all quantiles uniformly at the finest error? Second, if specific quantiles and their error bounds are requested a priori, can the necessary space usage and computation time be reduced? We answer both questions in the affirmative by formalizing them as the “high-biased ” and the “targeted ” quantiles problems, respectively, and presenting algorithms with provable guarantees, that perform significantly better than previously known solutions for these problems. We implemented our algorithms in the Gigascope data stream management system, and evaluated alternate approaches for maintaining the relevant summary structures. Our experimental results on real and synthetic IP data streams complement our theoretical analyses, and highlight the importance of lightweight, non-blocking implementations when maintaining summary structures over high-speed data streams."
 
+The full text publication is included in the `doc/cormode_et_al.pdf` (with permission of the author).
+
 ## Installation
 
 Building:
@@ -129,7 +131,7 @@ We can confirm that the maximum error we are expecting is probably not exceeded.
 
 ## Real world data
 
-The test data set is the population of 14593 settlements in the US which is a Pareto distribution ("long tail").
+The test data set is the population of 14593 settlements in the US which is a Pareto distribution ("long tail"). Please find the example data in the `private` directory.
 
 # Performance
 

--- a/src/quantile.erl
+++ b/src/quantile.erl
@@ -3,7 +3,6 @@
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
--export([ceil/1]).
 -define(DEBUG, true).
 -endif.
 
@@ -54,16 +53,6 @@ ranks(Size, Quantile) ->
 			[ceil(Size * Quantile)]
 	end.
 
--spec ceil(float()) -> integer().
-ceil(X) ->
-    T = erlang:trunc(X),
-    case (X - T) of
-        Neg when Neg < 0 -> T;
-        Pos when Pos > 0 -> T + 1;
-        _ -> T
-    end.
-
-
 % TESTS
 rank_average(Size, Quantile) ->
 	case ranks(Size, Quantile) of
@@ -81,8 +70,7 @@ quantile_test_() ->
 	fun test_setup/0,
 	fun test_teardown/1,
 	[
-		{"test ceil", fun  ceil_test/0}
-		,{"test ranks", fun ranks_test/0}
+		{"test ranks", fun ranks_test/0}
 		,{"test natural", fun natural_test/0}
 		,{"test even", fun even_test/0}
 		,{"test quantiles", fun quantile_test/0}
@@ -114,13 +102,6 @@ even_test() ->
 	,?assertEqual(true, even(-10))
 	,?assertEqual(false, even(11))
 	,?assertEqual(false, even(-11)).
-
-ceil_test() ->
-	?assertEqual(1, ceil(1.0))
-	,?assertEqual(2, ceil(1.1))
-	,?assertEqual(2, ceil(1.8))
-	,?assertEqual(-1, ceil(-1.8))
-	,?assertEqual(-1, ceil(-1.1)).
 
 quantile_test() ->
 	Samples1 = [3.0, 6.0, 7.0, 8.0, 8.0, 10.0, 13.0, 15.0, 16.0, 20.0]

--- a/src/quantile.erl
+++ b/src/quantile.erl
@@ -14,7 +14,7 @@
 -export([rank_average/2]).
 
 -spec quantile(float(), samples()) -> sample().
-quantile(0.0, [First|_]) ->
+quantile(Num, [First|_]) when Num == 0.0 ->
 	First;
 
 quantile(1.0, Samples) ->

--- a/src/quantile_estimator.app.src
+++ b/src/quantile_estimator.app.src
@@ -1,10 +1,10 @@
 {application, quantile_estimator,
  [
   {description, "A quantile estimator written in Erlang"},
-  {vsn, "0.2.1"},
+  {vsn, "0.3.0"},
   {licenses, ["MIT"]},
   {ex_doc, [
-      {source_url, <<"https://github.com/odo/quantile_estimator">>},
+      {source_url, <<"https://github.com/deadtrickster/quantile_estimator">>},
       {main, <<"README.md">>},
       {extras, [<<"LICENSE">>]}
   ]},
@@ -13,5 +13,6 @@
                   kernel,
                   stdlib
                  ]},
-  {env, []}
+  {env, []},
+  {links, [{"Github", "https://github.com/deadtrickster/quantile_estimator"}]}
  ]}.

--- a/src/quantile_estimator.app.src
+++ b/src/quantile_estimator.app.src
@@ -1,7 +1,13 @@
 {application, quantile_estimator,
  [
-  {description, ""},
+  {description, "A quantile estimator written in Erlang"},
   {vsn, "0.2.1"},
+  {licenses, ["MIT"]},
+  {ex_doc, [
+      {source_url, <<"https://github.com/odo/quantile_estimator">>},
+      {main, <<"README.md">>},
+      {extras, [<<"LICENSE">>]}
+  ]},
   {registered, []},
   {applications, [
                   kernel,

--- a/src/quantile_estimator.erl
+++ b/src/quantile_estimator.erl
@@ -160,14 +160,6 @@ quantile(Phi, Invariant, [Next = #group{g = Gi, delta = Deltai}|DataStructure], 
 			quantile(Phi, Invariant, DataStructure, N, Rank + Gi, Next)
 	end.
 
-floor(X) ->
-    T = erlang:trunc(X),
-    case (X - T) of
-        Neg when Neg < 0 -> T - 1;
-        Pos when Pos > 0 -> T;
-        _ -> T
-    end.
-
 clamp(X) when X >= 0 -> X;
 clamp(X) when X < 0 -> 0.
 
@@ -273,7 +265,7 @@ test_quantile() ->
 	% we create a set of 1000 random values and test if the guarantees are met
 	Invariant = f_biased(0.001),
 	N = 1000,
-	Samples = [random:uniform()||_ <- lists:seq(1, N)],
+	Samples = [rand:uniform()||_ <- lists:seq(1, N)],
 	Data = lists:foldl(fun(Sample, Stats) -> insert(Sample, Stats) end, quantile_estimator:new(Invariant), Samples),
 	% error_logger:info_msg("D:~p\n", [D]),
 	validate(Samples, Invariant, Data),
@@ -288,7 +280,7 @@ test_compression_biased() ->
 	% we create a set of 1000 random values and test if the guarantees are met
 	Invariant = f_biased(0.01),
 	N = 2000,
-	Samples = [random:uniform()||_ <- lists:seq(1, N)],
+	Samples = [rand:uniform()||_ <- lists:seq(1, N)],
 	Data = lists:foldl(fun(Sample, Stats) -> insert(Sample, Stats) end, quantile_estimator:new(Invariant), Samples),
 	DL = Data#quantile_estimator.data,
 	validate(Samples, Invariant, Data),
@@ -298,7 +290,7 @@ test_comression_targeted() ->
 	% we create a set of 1000 random values and test if the guarantees are met
 	Invariant = quantile_estimator:f_targeted([{0.05, 0.005}, {0.5, 0.02}, {0.95, 0.005}]),
 	N = 2000,
-	Samples = [random:uniform()||_ <- lists:seq(1, N)],
+	Samples = [rand:uniform()||_ <- lists:seq(1, N)],
 	Data = lists:foldl(fun(Sample, Stats) -> insert(Sample, Stats) end, quantile_estimator:new(Invariant), Samples),
 	DL = Data#quantile_estimator.data,
 	validate(Samples, Invariant, Data),
@@ -339,7 +331,7 @@ validate(Samples, Invariant, Estimate = #quantile_estimator{samples_count = N, d
 			Index(quantile:quantile(Q, SamplesSort), SamplesSort), 
 			Index(quantile(Q, Estimate), SamplesSort), 
 			abs(Index(quantile:quantile(Q, SamplesSort), SamplesSort) - Index(quantile(Q, Estimate), SamplesSort)),
-			quantile:ceil(Invariant(Index(quantile(Q, Estimate), SamplesSort), N))
+			ceil(Invariant(Index(quantile(Q, Estimate), SamplesSort), N))
 		} || Q <- Quantiles],
 	% [error_logger:info_msg("QReal:~p,~p,~p\n", [Q, N, quantile:quantile(Q, SamplesSort)]) || Q <- [0.0, 1.0]],
 	% [error_logger:info_msg("QEst:~p,~p,~p\n", [Q, N, quantile(Q, Invariant, Estimate)]) || Q <- [0.0, 1.0]],


### PR DESCRIPTION
Hello, 
Just a quick update of this library. 
For the context, we're using [prometheus](https://hex.pm/packages/prometheus), but we noticed that `quantile_estimator` doesn't specify a LICENSE, which could be a legal issue.
It was added in the upstream repo after you forked it, so I simply rebased, updated the `vsn` and added the Github link in `src/quantile_estimator.app.src`